### PR TITLE
Fix npm “build” script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,15 +17,15 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.7.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-            "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
+            "version": "12.12.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.8.tgz",
+            "integrity": "sha512-XLla8N+iyfjvsa0KKV+BP/iGSoTmwxsu5Ci5sM33z9TjohF72DEz95iNvD6pPmemvbQgxAv/909G73gUn8QR7w==",
             "dev": true
         },
         "abab": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
-            "integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+            "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
             "dev": true
         },
         "abbrev": {
@@ -840,9 +840,9 @@
             }
         },
         "bluebird": {
-            "version": "3.5.5",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+            "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
             "dev": true
         },
         "body": {
@@ -1094,9 +1094,9 @@
             }
         },
         "commander": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
         "component-emitter": {
@@ -1117,9 +1117,9 @@
             "dev": true
         },
         "convert-source-map": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
             "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
@@ -1132,9 +1132,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-            "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+            "version": "2.6.10",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+            "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -1374,17 +1374,17 @@
             "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "end-of-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "requires": {
                 "once": "^1.4.0"
             }
         },
         "error": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/error/-/error-7.2.0.tgz",
-            "integrity": "sha512-M6t3j3Vt3uDicrViMP5fLq2AeADNrCVFD8Oj4Qt2MHsX0mPYG7D5XdnEfSdRpaHQzjAJ19wu+I1mw9rQYMTAPg==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
+            "integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
             "dev": true,
             "requires": {
                 "string-template": "~0.2.1"
@@ -1400,9 +1400,9 @@
             }
         },
         "es-abstract": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
-            "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+            "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
             "requires": {
                 "es-to-primitive": "^1.2.0",
                 "function-bind": "^1.1.1",
@@ -1412,14 +1412,14 @@
                 "is-regex": "^1.0.4",
                 "object-inspect": "^1.6.0",
                 "object-keys": "^1.1.1",
-                "string.prototype.trimleft": "^2.0.0",
-                "string.prototype.trimright": "^2.0.0"
+                "string.prototype.trimleft": "^2.1.0",
+                "string.prototype.trimright": "^2.1.0"
             }
         },
         "es-to-primitive": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -1427,14 +1427,14 @@
             }
         },
         "es5-ext": {
-            "version": "0.10.51",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
-            "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+            "version": "0.10.52",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
+            "integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
             "dev": true,
             "requires": {
                 "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.1",
-                "next-tick": "^1.0.0"
+                "es6-symbol": "~3.1.2",
+                "next-tick": "~1.0.0"
             }
         },
         "es6-iterator": {
@@ -1449,13 +1449,13 @@
             }
         },
         "es6-symbol": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
-            "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
             "dev": true,
             "requires": {
                 "d": "^1.0.1",
-                "es5-ext": "^0.10.51"
+                "ext": "^1.1.2"
             }
         },
         "es6-template-strings": {
@@ -1595,6 +1595,23 @@
             "dev": true,
             "requires": {
                 "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "ext": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz",
+            "integrity": "sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -1980,9 +1997,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-            "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
             "dev": true
         },
         "graceful-readlink": {
@@ -2332,9 +2349,9 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbols": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "has-value": {
             "version": "1.0.0",
@@ -2405,9 +2422,9 @@
             "dev": true
         },
         "hosted-git-info": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-            "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+            "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
             "dev": true
         },
         "html-encoding-sniffer": {
@@ -2542,9 +2559,9 @@
             "dev": true
         },
         "is-buffer": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-            "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+            "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         },
         "is-callable": {
             "version": "1.1.4",
@@ -3113,18 +3130,18 @@
             }
         },
         "mime-db": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+            "version": "1.42.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+            "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.24",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+            "version": "2.1.25",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+            "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
             "dev": true,
             "requires": {
-                "mime-db": "1.40.0"
+                "mime-db": "1.42.0"
             }
         },
         "mimic-fn": {
@@ -3324,9 +3341,9 @@
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "nwsapi": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
-            "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
             "dev": true
         },
         "oauth-sign": {
@@ -3379,9 +3396,9 @@
             }
         },
         "object-inspect": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
         },
         "object-keys": {
             "version": "1.1.1",
@@ -3457,17 +3474,17 @@
             }
         },
         "optionator": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
             "dev": true,
             "requires": {
                 "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
+                "fast-levenshtein": "~2.0.6",
                 "levn": "~0.3.0",
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "word-wrap": "~1.2.3"
             }
         },
         "os-homedir": {
@@ -3731,9 +3748,9 @@
             "dev": true
         },
         "qs": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
-            "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==",
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+            "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
             "dev": true
         },
         "raw-body": {
@@ -3934,21 +3951,21 @@
             }
         },
         "request-promise-core": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+            "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.11"
+                "lodash": "^4.17.15"
             }
         },
         "request-promise-native": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+            "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
             "dev": true,
             "requires": {
-                "request-promise-core": "1.1.2",
+                "request-promise-core": "1.1.3",
                 "stealthy-require": "^1.1.1",
                 "tough-cookie": "^2.3.3"
             },
@@ -4535,9 +4552,9 @@
                     "dev": true
                 },
                 "source-map-support": {
-                    "version": "0.5.13",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-                    "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+                    "version": "0.5.16",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+                    "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
                     "dev": true,
                     "requires": {
                         "buffer-from": "^1.0.0",
@@ -4739,9 +4756,9 @@
             "dev": true
         },
         "type": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
-            "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
             "dev": true
         },
         "type-check": {
@@ -4760,12 +4777,12 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-            "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+            "version": "3.6.9",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+            "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
             "dev": true,
             "requires": {
-                "commander": "~2.20.0",
+                "commander": "~2.20.3",
                 "source-map": "~0.6.1"
             },
             "dependencies": {
@@ -4973,9 +4990,9 @@
             "dev": true
         },
         "whatwg-url": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-            "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+            "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
             "dev": true,
             "requires": {
                 "lodash.sortby": "^4.7.0",
@@ -5010,10 +5027,10 @@
                 "string-width": "^1.0.2 || 2"
             }
         },
-        "wordwrap": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
         },
         "wrap-ansi": {
@@ -5051,9 +5068,9 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
-            "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
+            "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
             "dev": true,
             "requires": {
                 "async-limiter": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "moment": "2.24.0"
     },
     "scripts": {
-        "build2": "grunt",
-        "build": "rm -rf dist && mkdir dist && cp -a src/* dist"
+        "build": "grunt"
     }
 }


### PR DESCRIPTION
There was `build` and `build2`, which made things confusing. Only one is worky.

While at it, update the package lock file too